### PR TITLE
Add run.py wrapper script and fix OpenCV compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,22 @@ Integrated_Webcam_HD: Integrate (usb-0000:00:14.0-3):
 
 In this example the thermal camera is "USB Camera" and the device number is **4** (from /dev/video4).
 
-Assuming the device number is 0 simply issue: **python3 tc001v4.2.py --device 0**
+### Using the Wrapper Script (Recommended)
+
+The easiest way to run the program is using the `run.py` wrapper script:
+
+```bash
+./run.py -l, --list     List available video devices
+./run.py -u, --use <n>  Run thermal camera with specified device number
+./run.py -i, --install  Install required dependencies (python3-opencv, v4l-utils)
+./run.py -h, --help     Show this help message
+```
+
+For example: **./run.py -u 4**
+
+### Running Directly
+
+Alternatively, you can run the main script directly: **python3 src/tc001v4.2.py --device 4**
 
 **Note**
 This is in Alpha. No error checking has been implemented yet! So if the program tries to start, then quits, either a camera is not connected, or you have entered the wrong device number.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Python3 OpenCV Must be installed:
 
 Run: **sudo apt-get install python3-opencv**
 
+v4l-utils is also required to list video devices:
+
+Run: **sudo apt install v4l-utils**
+
 
 
 ## Running the Program
@@ -75,6 +79,24 @@ In src you will find two programs:
 **tc001v4.2.py** The main program!
 
 To run it plug in the thermal camera and run: **v4l2-ctl --list-devices** to list the devices on the system. You will need its device number.
+
+```bash
+❯ v4l2-ctl --list-devices
+USB Camera: USB Camera (usb-0000:00:14.0-12.3.2.4.3):
+        /dev/video4
+        /dev/video5
+        /dev/media2
+
+Integrated_Webcam_HD: Integrate (usb-0000:00:14.0-3):
+        /dev/video0
+        /dev/video1
+        /dev/video2
+        /dev/video3
+        /dev/media0
+        /dev/media1
+```
+
+In this example the thermal camera is "USB Camera" and the device number is **4** (from /dev/video4).
 
 Assuming the device number is 0 simply issue: **python3 tc001v4.2.py --device 0**
 

--- a/run.py
+++ b/run.py
@@ -47,15 +47,10 @@ def print_usage():
     print("""PyThermalCamera - Thermal Camera Software for Topdon TC001
 
 Usage:
-  ./run.py --devices              List available video devices
-  ./run.py --dev <number>         Run thermal camera with specified device number
-  ./run.py --install-dependencies Install required dependencies (python3-opencv, v4l-utils)
-  ./run.py -h, --help             Show this help message
-
-Examples:
-  ./run.py --install-dependencies # Install dependencies
-  ./run.py --devices              # List all video devices
-  ./run.py --dev 4                # Run with device /dev/video4
+  ./run.py -l, --list     List available video devices
+  ./run.py -u, --use <n>  Run thermal camera with specified device number
+  ./run.py -i, --install  Install required dependencies (python3-opencv, v4l-utils)
+  ./run.py -h, --help     Show this help message
 """)
 
 def main():
@@ -67,9 +62,9 @@ def main():
         description="PyThermalCamera - Thermal Camera Software for Topdon TC001",
         add_help=False
     )
-    parser.add_argument("--devices", action="store_true", help="List available video devices")
-    parser.add_argument("--dev", type=int, metavar="<number>", help="Device number to use")
-    parser.add_argument("--install-dependencies", action="store_true", help="Install required dependencies")
+    parser.add_argument("-l", "--list", action="store_true", help="List available video devices")
+    parser.add_argument("-u", "--use", type=int, metavar="<n>", help="Device number to use")
+    parser.add_argument("-i", "--install", action="store_true", help="Install required dependencies")
     parser.add_argument("-h", "--help", action="store_true", help="Show this help message")
 
     args = parser.parse_args()
@@ -78,12 +73,12 @@ def main():
         print_usage()
         sys.exit(0)
 
-    if args.install_dependencies:
+    if args.install:
         install_dependencies()
-    elif args.devices:
+    elif args.list:
         list_devices()
-    elif args.dev is not None:
-        run_camera(args.dev)
+    elif args.use is not None:
+        run_camera(args.use)
     else:
         print_usage()
         sys.exit(1)

--- a/run.py
+++ b/run.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Wrapper script for PyThermalCamera."""
+
+import argparse
+import subprocess
+import sys
+import os
+
+def list_devices():
+    """List available video devices using v4l2-ctl."""
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "--list-devices"],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode == 0:
+            print(result.stdout)
+        else:
+            print("Error listing devices:", result.stderr, file=sys.stderr)
+            sys.exit(1)
+    except FileNotFoundError:
+        print("v4l2-ctl not found. Install with: sudo apt install v4l-utils", file=sys.stderr)
+        sys.exit(1)
+
+def run_camera(device):
+    """Run the thermal camera application."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    tc001_script = os.path.join(script_dir, "src", "tc001v4.2.py")
+    subprocess.run(["python3", tc001_script, "--device", str(device)])
+
+def install_dependencies():
+    """Install required dependencies."""
+    print("Installing dependencies...")
+    packages = ["python3-opencv", "v4l-utils"]
+    result = subprocess.run(
+        ["sudo", "apt", "install", "-y"] + packages
+    )
+    if result.returncode == 0:
+        print("Dependencies installed successfully.")
+    else:
+        print("Error installing dependencies.", file=sys.stderr)
+        sys.exit(1)
+
+def print_usage():
+    """Print usage information."""
+    print("""PyThermalCamera - Thermal Camera Software for Topdon TC001
+
+Usage:
+  ./run.py --devices              List available video devices
+  ./run.py --dev <number>         Run thermal camera with specified device number
+  ./run.py --install-dependencies Install required dependencies (python3-opencv, v4l-utils)
+  ./run.py -h, --help             Show this help message
+
+Examples:
+  ./run.py --install-dependencies # Install dependencies
+  ./run.py --devices              # List all video devices
+  ./run.py --dev 4                # Run with device /dev/video4
+""")
+
+def main():
+    if len(sys.argv) == 1:
+        print_usage()
+        sys.exit(0)
+
+    parser = argparse.ArgumentParser(
+        description="PyThermalCamera - Thermal Camera Software for Topdon TC001",
+        add_help=False
+    )
+    parser.add_argument("--devices", action="store_true", help="List available video devices")
+    parser.add_argument("--dev", type=int, metavar="<number>", help="Device number to use")
+    parser.add_argument("--install-dependencies", action="store_true", help="Install required dependencies")
+    parser.add_argument("-h", "--help", action="store_true", help="Show this help message")
+
+    args = parser.parse_args()
+
+    if args.help:
+        print_usage()
+        sys.exit(0)
+
+    if args.install_dependencies:
+        install_dependencies()
+    elif args.devices:
+        list_devices()
+    elif args.dev is not None:
+        run_camera(args.dev)
+    else:
+        print_usage()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/tc001v4.2.py
+++ b/src/tc001v4.2.py
@@ -58,7 +58,7 @@ cap = cv2.VideoCapture('/dev/video'+str(dev), cv2.CAP_V4L)
 if isPi == True:
 	cap.set(cv2.CAP_PROP_CONVERT_RGB, 0.0)
 else:
-	cap.set(cv2.CAP_PROP_CONVERT_RGB, False)
+	cap.set(cv2.CAP_PROP_CONVERT_RGB, 0.0)
 
 #256x192 General settings
 width = 256 #Sensor width


### PR DESCRIPTION
## Summary

This PR adds a convenient wrapper script and fixes compatibility with newer OpenCV versions.

### New: `run.py` Startup Script

A new `run.py` script in the project root provides an easy entry point for users:

```bash
./run.py -l, --list     # List available video devices
./run.py -u, --use <n>  # Run thermal camera with device number
./run.py -i, --install  # Install dependencies (python3-opencv, v4l-utils)
./run.py -h, --help     # Show help
```

**Why?** Users no longer need to remember the path to `src/tc001v4.2.py` or the exact parameter names. The wrapper handles everything from one place.

### Fix: OpenCV Compatibility

Changed `cap.set(cv2.CAP_PROP_CONVERT_RGB, False)` to `cap.set(cv2.CAP_PROP_CONVERT_RGB, 0.0)`.

**Why?** Newer OpenCV versions require a `float` value instead of `bool`, causing a `TypeError` on startup.

### Documentation: v4l-utils Dependency

Added `v4l-utils` to the README dependencies section with installation instructions.

**Why?** `v4l2-ctl --list-devices` is required to find the camera device number, but the package wasn't listed as a dependency.

### Documentation: Device Listing Example

Added example output of `v4l2-ctl --list-devices` to the README.

**Why?** Helps users understand how to identify their thermal camera (look for "USB Camera") and which device number to use (first `/dev/videoX` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)